### PR TITLE
Fix renamed collection drop in transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.2
+
+- (bug) Dropping collection as part of rename now works
+
 # v1.1.1
 
 - (feature) Collection renaming for mongodb

--- a/mongodb/collection_operator.go
+++ b/mongodb/collection_operator.go
@@ -46,15 +46,16 @@ func (o *MongodbCollectionOperator) Rename(
 		if err != nil {
 			return err
 		}
-
-		if drop {
-			return o.Drop(ctx, collection)
-		}
 		return nil
 	}
 
 	if err := o.connection.WithTransaction(ctx, handler); err != nil {
 		return nil, err
+	}
+	if drop {
+		if err := o.Drop(ctx, collection); err != nil {
+			return nil, err
+		}
 	}
 	return clerk.NewCollectionWithDatabase(collection.Database, renameTo), nil
 }


### PR DESCRIPTION
Renaming a collection would have the optional drop of the old collection as part of the transaction. This is not supported by the MongoDB driver and results in an error. This PR extracts the drop action from the transaction in which the collection is renamed.